### PR TITLE
New buildspec for combined large repo tests

### DIFF
--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -5,13 +5,13 @@ runAs: root
 shell: bash
 env:
   variables:
-    "githubSource": "TestBuildSource1_GitHub"
-    "gitlabSource": "TestBuildSource1_GitLab"
-    "bitbucketCloudSource": "TestBuildSource1_BitbucketCloud"
-    "bitbucketServerSource": "TestBuildSource1_BitbucketServer"
-    "publicGitlabServerSource": "TestBuildSource1_PublicGitlabServer"
-    "vbsSource": "TestBuildSource1_Vbs"
-    "zipFilesDirectoryName": "zipFiles"
+    "githubSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_GitHub"
+    "gitlabSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_GitLab"
+    "bitbucketCloudSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_BitbucketCloud"
+    "bitbucketServerSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_BitbucketServer"
+    "publicGitlabServerSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_PublicGitlabServer"
+    "vbsSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_Vbs"
+    "zipFilesDirectoryPath": "${OCI_WORKSPACE_DIR}/zipFiles"
   exportedVariables:
    - GITHUB_MD5_HASH
    - GITLAB_MD5_HASH
@@ -23,12 +23,12 @@ steps:
   - type: Command
     name: "Create directory for storing zip files"
     command: |
-      mkdir ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}
+      mkdir ${zipFilesDirectoryPath}
   - type: Command
     name: "Calculating MD5 Hash of Github Large Repo"
     command: |
-      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/github.zip ${OCI_WORKSPACE_DIR}/${githubSource}
-      export GITHUB_MD5_HASH=`md5sum github.zip | awk '{ print $1 }'`
+      zip -r ${zipFilesDirectoryPath}/github.zip ${githubSourcePath}
+      export GITHUB_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/github.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -36,8 +36,8 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Gitlab Large Repo"
     command: |
-      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/gitlab.zip ${OCI_WORKSPACE_DIR}/${gitlabSource}
-      export GITLAB_MD5_HASH=`md5sum gitlab.zip | awk '{ print $1 }'`
+      zip -r ${zipFilesDirectoryPath}/gitlab.zip ${OCI_WORKSPACE_DIR}/${gitlabSourcePath}
+      export GITLAB_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/gitlab.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -45,8 +45,8 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
     command: |
-      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/bitbucketCloud.zip ${OCI_WORKSPACE_DIR}/${bitbucketCloudSource}
-      export BITBUCKET_CLOUD_MD5_HASH=`md5sum bitbucketCloud.zip | awk '{ print $1 }'`
+      zip -r ${zipFilesDirectoryPath}/bitbucketCloud.zip ${OCI_WORKSPACE_DIR}/${bitbucketCloudSourcePath}
+      export BITBUCKET_CLOUD_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/bitbucketCloud.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -54,8 +54,8 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
     command: |
-      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/bitbucketServer.zip ${OCI_WORKSPACE_DIR}/${bitbucketServerSource}
-      export BITBUCKET_SERVER_MD5_HASH=`md5sum bitbucketServer.zip | awk '{ print $1 }'`
+      zip -r ${zipFilesDirectoryPath}/bitbucketServer.zip ${OCI_WORKSPACE_DIR}/${bitbucketServerSourcePath}
+      export BITBUCKET_SERVER_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/bitbucketServer.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -63,8 +63,8 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
     command: |
-      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/publicGitlabServer.zip ${OCI_WORKSPACE_DIR}/${publicGitlabServerSource}
-      export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum publicGitlabServer.zip | awk '{ print $1 }'`
+      zip -r ${zipFilesDirectoryPath}/publicGitlabServer.zip ${OCI_WORKSPACE_DIR}/${publicGitlabServerSourcePath}
+      export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/publicGitlabServer.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -72,8 +72,8 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of VBS Large Repo"
     command: |
-      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/vbs.zip ${OCI_WORKSPACE_DIR}/${vbsSource}
-      export VBS_MD5_HASH=`md5sum vbs.zip | awk '{ print $1 }'`
+      zip -r ${zipFilesDirectoryPath}/vbs.zip ${OCI_WORKSPACE_DIR}/${vbsSourcePath}
+      export VBS_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/vbs.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -81,7 +81,7 @@ steps:
   - type: Command
     name: "Deleting all the zip files"
     command: |
-      rm -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}
+      rm -r ${zipFilesDirectoryPath}
 #  - type: Command
 #    name: "Building spark (Github Large Repo) in local"
 #    command: |

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -74,14 +74,13 @@ steps:
       - type: Command
         command: |
           echo "Calculating MD5 Hash of VBS Large Repo failed :("
-#  - type: Command
-#    name: "Building spark (Github Large Repo) in local"
-#    command: |
-#      cd ${OCI_WORKSPACE_DIR}/${githubSource}
-#      chmod -R +x ./build/mvn
-#      ./build/mvn -DskipTests clean package
-#  - type: Command
-#    name: "run the Pi example locally"
-#    command: |
-#      chmod -R +x .
-#      ./bin/run-example SparkPi
+  - type: Command
+    name: "Building spark (Github Large Repo)"
+    command: |
+      chmod -R +x ./build/mvn
+      ./build/mvn -DskipTests clean package
+  - type: Command
+    name: "Run the Pi example locally"
+    command: |
+      chmod -R +x .
+      ./bin/run-example SparkPi

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -6,11 +6,11 @@ shell: bash
 env:
   exportedVariables:
    - GITHUB_MD5_HASH
-#   - GITLAB_MD5_HASH
-#   - BITBUCKET_CLOUD_MD5_HASH
-#   - BITBUCKET_SERVER_MD5_HASH
-#   - PUBLIC_GITLAB_SERVER_MD5_HASH
-#   - VBS_MD5_HASH
+   - GITLAB_MD5_HASH
+   - BITBUCKET_CLOUD_MD5_HASH
+   - BITBUCKET_SERVER_MD5_HASH
+   - PUBLIC_GITLAB_SERVER_MD5_HASH
+   - VBS_MD5_HASH
 steps:
   - type: Command
     name: "Calculating MD5 Hash of Github Large Repo"
@@ -23,52 +23,52 @@ steps:
       - type: Command
         command: |
           echo "Calculating MD5 Hash of Github Large Repo failed :("
-#  - type: Command
-#    name: "Calculating MD5 Hash of Gitlab Large Repo"
-#    command: |
-#      zip -d TestBuildSource_GitLab.zip apache-spark/.git/*
-#      export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
-#      echo Gitlab hash is $GITLAB_MD5_HASH
-#    onFailure:
-#      - type: Command
-#        command: |
-#          echo "Calculating MD5 Hash of Gitlab Large Repo failed :("
-#  - type: Command
-#    name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
-#    command: |
-#      zip -d TestBuildSource_BitbucketCloud.zip apache-spark/.git/*
-#      export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
-#    onFailure:
-#      - type: Command
-#        command: |
-#          echo "Calculating MD5 Hash of Bitbucket Cloud Large Repo failed :("
-#  - type: Command
-#    name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
-#    command: |
-#      zip -d TestBuildSource_BitbucketServer.zip apache-spark/.git/*
-#      export BITBUCKET_SERVER_MD5_HASH=`md5sum TestBuildSource_BitbucketServer.zip | awk '{ print $1 }'`
-#    onFailure:
-#      - type: Command
-#        command: |
-#          echo "Calculating MD5 Hash of Bitbucket Server Large Repo failed :("
-#  - type: Command
-#    name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
-#    command: |
-#      zip -d TestBuildSource_PublicGitlabServer.zip apache-spark/.git/*
-#      export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum TestBuildSource_PublicGitlabServer.zip | awk '{ print $1 }'`
-#    onFailure:
-#      - type: Command
-#        command: |
-#          echo "Calculating MD5 Hash of Public Gitlab Server Large Repo failed :("
-#  - type: Command
-#    name: "Calculating MD5 Hash of VBS Large Repo"
-#    command: |
-#      zip -d TestBuildSource_Vbs.zip apache-spark/.git/*
-#      export VBS_MD5_HASH=`md5sum TestBuildSource_Vbs.zip | awk '{ print $1 }'`
-#    onFailure:
-#      - type: Command
-#        command: |
-#          echo "Calculating MD5 Hash of VBS Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of Gitlab Large Repo"
+    command: |
+      zip -d TestBuildSource_GitLab.zip */.git/*
+      export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
+      echo Gitlab hash is $GITLAB_MD5_HASH
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of Gitlab Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
+    command: |
+      zip -d TestBuildSource_BitbucketCloud.zip */.git/*
+      export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of Bitbucket Cloud Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
+    command: |
+      zip -d TestBuildSource_BitbucketServer.zip */.git/*
+      export BITBUCKET_SERVER_MD5_HASH=`md5sum TestBuildSource_BitbucketServer.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of Bitbucket Server Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
+    command: |
+      zip -d TestBuildSource_PublicGitlabServer.zip */.git/*
+      export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum TestBuildSource_PublicGitlabServer.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of Public Gitlab Server Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of VBS Large Repo"
+    command: |
+      zip -d TestBuildSource_Vbs.zip */.git/*
+      export VBS_MD5_HASH=`md5sum TestBuildSource_Vbs.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of VBS Large Repo failed :("
 #  - type: Command
 #    name: "Building spark (Github Large Repo) in local"
 #    command: |

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -17,6 +17,7 @@ steps:
     command: |
       zip -d TestBuildSource_GitHub.zip TestBuildSource_GitHub/.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
+      echo Github hash is $GITHUB_MD5_HASH
     onFailure:
       - type: Command
         command: |
@@ -26,6 +27,7 @@ steps:
     command: |
       zip -d TestBuildSource_GitLab.zip TestBuildSource_GitLab/.git/*
       export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
+      echo Gitlab hash is $GITLAB_MD5_HASH
     onFailure:
       - type: Command
         command: |

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -15,6 +15,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Github Large Repo"
     command: |
+      cd ..
       zip -d TestBuildSource_GitHub.zip TestBuildSource_GitHub/.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
       echo Github hash is $GITHUB_MD5_HASH

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -4,14 +4,6 @@ timeoutInSeconds: 20000
 runAs: root
 shell: bash
 env:
-  variables:
-    "githubSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_GitHub"
-    "gitlabSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_GitLab"
-    "bitbucketCloudSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_BitbucketCloud"
-    "bitbucketServerSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_BitbucketServer"
-    "publicGitlabServerSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_PublicGitlabServer"
-    "vbsSourcePath": "${OCI_WORKSPACE_DIR}/TestBuildSource_Vbs"
-    "zipFilesDirectoryPath": "${OCI_WORKSPACE_DIR}/zipFiles"
   exportedVariables:
    - GITHUB_MD5_HASH
    - GITLAB_MD5_HASH
@@ -21,14 +13,10 @@ env:
    - VBS_MD5_HASH
 steps:
   - type: Command
-    name: "Create directory for storing zip files"
-    command: |
-      mkdir ${zipFilesDirectoryPath}
-  - type: Command
     name: "Calculating MD5 Hash of Github Large Repo"
     command: |
-      zip -r ${zipFilesDirectoryPath}/github.zip ${githubSourcePath}
-      export GITHUB_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/github.zip | awk '{ print $1 }'`
+      zip -d TestBuildSource_GitHub.zip TestBuildSource_GitHub/.git/*
+      export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -36,8 +24,8 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Gitlab Large Repo"
     command: |
-      zip -r ${zipFilesDirectoryPath}/gitlab.zip ${OCI_WORKSPACE_DIR}/${gitlabSourcePath}
-      export GITLAB_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/gitlab.zip | awk '{ print $1 }'`
+      zip -d TestBuildSource_GitLab.zip TestBuildSource_GitLab/.git/*
+      export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -45,8 +33,8 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
     command: |
-      zip -r ${zipFilesDirectoryPath}/bitbucketCloud.zip ${OCI_WORKSPACE_DIR}/${bitbucketCloudSourcePath}
-      export BITBUCKET_CLOUD_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/bitbucketCloud.zip | awk '{ print $1 }'`
+      zip -d TestBuildSource_BitbucketCloud.zip TestBuildSource_BitbucketCloud/.git/*
+      export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -54,8 +42,8 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
     command: |
-      zip -r ${zipFilesDirectoryPath}/bitbucketServer.zip ${OCI_WORKSPACE_DIR}/${bitbucketServerSourcePath}
-      export BITBUCKET_SERVER_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/bitbucketServer.zip | awk '{ print $1 }'`
+      zip -d TestBuildSource_BitbucketServer.zip TestBuildSource_BitbucketServer/.git/*
+      export BITBUCKET_SERVER_MD5_HASH=`md5sum TestBuildSource_BitbucketServer.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -63,8 +51,8 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
     command: |
-      zip -r ${zipFilesDirectoryPath}/publicGitlabServer.zip ${OCI_WORKSPACE_DIR}/${publicGitlabServerSourcePath}
-      export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/publicGitlabServer.zip | awk '{ print $1 }'`
+      zip -d TestBuildSource_PublicGitlabServer.zip TestBuildSource_PublicGitlabServer/.git/*
+      export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum TestBuildSource_PublicGitlabServer.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
@@ -72,16 +60,12 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of VBS Large Repo"
     command: |
-      zip -r ${zipFilesDirectoryPath}/vbs.zip ${OCI_WORKSPACE_DIR}/${vbsSourcePath}
-      export VBS_MD5_HASH=`md5sum ${zipFilesDirectoryPath}/vbs.zip | awk '{ print $1 }'`
+      zip -d TestBuildSource_Vbs.zip TestBuildSource_Vbs/.git/*
+      export VBS_MD5_HASH=`md5sum TestBuildSource_Vbs.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |
           echo "Calculating MD5 Hash of VBS Large Repo failed :("
-  - type: Command
-    name: "Deleting all the zip files"
-    command: |
-      rm -r ${zipFilesDirectoryPath}
 #  - type: Command
 #    name: "Building spark (Github Large Repo) in local"
 #    command: |

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -16,7 +16,7 @@ steps:
     name: "Calculating MD5 Hash of Github Large Repo"
     command: |
       cd ..
-      zip -d TestBuildSource_GitHub.zip TestBuildSource_GitHub/.git/*
+      zip -d TestBuildSource_GitHub.zip apache-spark/.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
       echo Github hash is $GITHUB_MD5_HASH
     onFailure:
@@ -26,7 +26,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Gitlab Large Repo"
     command: |
-      zip -d TestBuildSource_GitLab.zip TestBuildSource_GitLab/.git/*
+      zip -d TestBuildSource_GitLab.zip apache-spark/.git/*
       export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
       echo Gitlab hash is $GITLAB_MD5_HASH
     onFailure:
@@ -36,7 +36,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
     command: |
-      zip -d TestBuildSource_BitbucketCloud.zip TestBuildSource_BitbucketCloud/.git/*
+      zip -d TestBuildSource_BitbucketCloud.zip apache-spark/.git/*
       export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
@@ -45,7 +45,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
     command: |
-      zip -d TestBuildSource_BitbucketServer.zip TestBuildSource_BitbucketServer/.git/*
+      zip -d TestBuildSource_BitbucketServer.zip apache-spark/.git/*
       export BITBUCKET_SERVER_MD5_HASH=`md5sum TestBuildSource_BitbucketServer.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
@@ -54,7 +54,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
     command: |
-      zip -d TestBuildSource_PublicGitlabServer.zip TestBuildSource_PublicGitlabServer/.git/*
+      zip -d TestBuildSource_PublicGitlabServer.zip apache-spark/.git/*
       export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum TestBuildSource_PublicGitlabServer.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
@@ -63,7 +63,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of VBS Large Repo"
     command: |
-      zip -d TestBuildSource_Vbs.zip TestBuildSource_Vbs/.git/*
+      zip -d TestBuildSource_Vbs.zip apache-spark/.git/*
       export VBS_MD5_HASH=`md5sum TestBuildSource_Vbs.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -6,11 +6,11 @@ shell: bash
 env:
   exportedVariables:
    - GITHUB_MD5_HASH
-   - GITLAB_MD5_HASH
-   - BITBUCKET_CLOUD_MD5_HASH
-   - BITBUCKET_SERVER_MD5_HASH
-   - PUBLIC_GITLAB_SERVER_MD5_HASH
-   - VBS_MD5_HASH
+#   - GITLAB_MD5_HASH
+#   - BITBUCKET_CLOUD_MD5_HASH
+#   - BITBUCKET_SERVER_MD5_HASH
+#   - PUBLIC_GITLAB_SERVER_MD5_HASH
+#   - VBS_MD5_HASH
 steps:
   - type: Command
     name: "Calculating MD5 Hash of Github Large Repo"
@@ -23,52 +23,52 @@ steps:
       - type: Command
         command: |
           echo "Calculating MD5 Hash of Github Large Repo failed :("
-  - type: Command
-    name: "Calculating MD5 Hash of Gitlab Large Repo"
-    command: |
-      zip -d TestBuildSource_GitLab.zip apache-spark/.git/*
-      export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
-      echo Gitlab hash is $GITLAB_MD5_HASH
-    onFailure:
-      - type: Command
-        command: |
-          echo "Calculating MD5 Hash of Gitlab Large Repo failed :("
-  - type: Command
-    name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
-    command: |
-      zip -d TestBuildSource_BitbucketCloud.zip apache-spark/.git/*
-      export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
-    onFailure:
-      - type: Command
-        command: |
-          echo "Calculating MD5 Hash of Bitbucket Cloud Large Repo failed :("
-  - type: Command
-    name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
-    command: |
-      zip -d TestBuildSource_BitbucketServer.zip apache-spark/.git/*
-      export BITBUCKET_SERVER_MD5_HASH=`md5sum TestBuildSource_BitbucketServer.zip | awk '{ print $1 }'`
-    onFailure:
-      - type: Command
-        command: |
-          echo "Calculating MD5 Hash of Bitbucket Server Large Repo failed :("
-  - type: Command
-    name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
-    command: |
-      zip -d TestBuildSource_PublicGitlabServer.zip apache-spark/.git/*
-      export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum TestBuildSource_PublicGitlabServer.zip | awk '{ print $1 }'`
-    onFailure:
-      - type: Command
-        command: |
-          echo "Calculating MD5 Hash of Public Gitlab Server Large Repo failed :("
-  - type: Command
-    name: "Calculating MD5 Hash of VBS Large Repo"
-    command: |
-      zip -d TestBuildSource_Vbs.zip apache-spark/.git/*
-      export VBS_MD5_HASH=`md5sum TestBuildSource_Vbs.zip | awk '{ print $1 }'`
-    onFailure:
-      - type: Command
-        command: |
-          echo "Calculating MD5 Hash of VBS Large Repo failed :("
+#  - type: Command
+#    name: "Calculating MD5 Hash of Gitlab Large Repo"
+#    command: |
+#      zip -d TestBuildSource_GitLab.zip apache-spark/.git/*
+#      export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
+#      echo Gitlab hash is $GITLAB_MD5_HASH
+#    onFailure:
+#      - type: Command
+#        command: |
+#          echo "Calculating MD5 Hash of Gitlab Large Repo failed :("
+#  - type: Command
+#    name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
+#    command: |
+#      zip -d TestBuildSource_BitbucketCloud.zip apache-spark/.git/*
+#      export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
+#    onFailure:
+#      - type: Command
+#        command: |
+#          echo "Calculating MD5 Hash of Bitbucket Cloud Large Repo failed :("
+#  - type: Command
+#    name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
+#    command: |
+#      zip -d TestBuildSource_BitbucketServer.zip apache-spark/.git/*
+#      export BITBUCKET_SERVER_MD5_HASH=`md5sum TestBuildSource_BitbucketServer.zip | awk '{ print $1 }'`
+#    onFailure:
+#      - type: Command
+#        command: |
+#          echo "Calculating MD5 Hash of Bitbucket Server Large Repo failed :("
+#  - type: Command
+#    name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
+#    command: |
+#      zip -d TestBuildSource_PublicGitlabServer.zip apache-spark/.git/*
+#      export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum TestBuildSource_PublicGitlabServer.zip | awk '{ print $1 }'`
+#    onFailure:
+#      - type: Command
+#        command: |
+#          echo "Calculating MD5 Hash of Public Gitlab Server Large Repo failed :("
+#  - type: Command
+#    name: "Calculating MD5 Hash of VBS Large Repo"
+#    command: |
+#      zip -d TestBuildSource_Vbs.zip apache-spark/.git/*
+#      export VBS_MD5_HASH=`md5sum TestBuildSource_Vbs.zip | awk '{ print $1 }'`
+#    onFailure:
+#      - type: Command
+#        command: |
+#          echo "Calculating MD5 Hash of VBS Large Repo failed :("
 #  - type: Command
 #    name: "Building spark (Github Large Repo) in local"
 #    command: |

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -16,7 +16,7 @@ steps:
     name: "Calculating MD5 Hash of Github Large Repo"
     command: |
       cd ${OCI_WORKSPACE_DIR}
-      zip -d TestBuildSource_GitHub.zip */.git/*
+      zip -dq TestBuildSource_GitHub.zip */.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
@@ -26,7 +26,7 @@ steps:
     name: "Calculating MD5 Hash of Gitlab Large Repo"
     command: |
       cd ${OCI_WORKSPACE_DIR}
-      zip -d TestBuildSource_GitLab.zip */.git/*
+      zip -dq TestBuildSource_GitLab.zip */.git/*
       export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
@@ -36,7 +36,7 @@ steps:
     name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
     command: |
       cd ${OCI_WORKSPACE_DIR}
-      zip -d TestBuildSource_BitbucketCloud.zip */.git/*
+      zip -dq TestBuildSource_BitbucketCloud.zip */.git/*
       export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
@@ -46,7 +46,7 @@ steps:
     name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
     command: |
       cd ${OCI_WORKSPACE_DIR}
-      zip -d TestBuildSource_BitbucketServer.zip */.git/*
+      zip -dq TestBuildSource_BitbucketServer.zip */.git/*
       export BITBUCKET_SERVER_MD5_HASH=`md5sum TestBuildSource_BitbucketServer.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
@@ -56,7 +56,7 @@ steps:
     name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
     command: |
       cd ${OCI_WORKSPACE_DIR}
-      zip -d TestBuildSource_PublicGitlabServer.zip */.git/*
+      zip -dq TestBuildSource_PublicGitlabServer.zip */.git/*
       export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum TestBuildSource_PublicGitlabServer.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
@@ -66,7 +66,7 @@ steps:
     name: "Calculating MD5 Hash of VBS Large Repo"
     command: |
       cd ${OCI_WORKSPACE_DIR}
-      zip -d TestBuildSource_Vbs.zip */.git/*
+      zip -dq TestBuildSource_Vbs.zip */.git/*
       export VBS_MD5_HASH=`md5sum TestBuildSource_Vbs.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -42,7 +42,7 @@ steps:
     name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
     command: |
       zip -d TestBuildSource_BitbucketCloud.zip */.git/*
-      export BITUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
+      export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -16,7 +16,7 @@ steps:
     name: "Calculating MD5 Hash of Github Large Repo"
     command: |
       cd ..
-      zip -d TestBuildSource_GitHub.zip apache-spark/.git/*
+      zip -d TestBuildSource_GitHub.zip */.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
       echo Github hash is $GITHUB_MD5_HASH
     onFailure:

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -20,7 +20,6 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Github Large Repo"
     command: |
-#      cd ..
       zip -d TestBuildSource_GitHub.zip */.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
       echo Github hash is $GITHUB_MD5_HASH

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -20,6 +20,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Github Large Repo"
     command: |
+      pwd
       zip -d TestBuildSource_GitHub.zip */.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
       echo Github hash is $GITHUB_MD5_HASH
@@ -30,6 +31,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Gitlab Large Repo"
     command: |
+      pwd
       zip -d TestBuildSource_GitLab.zip */.git/*
       export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
       echo Gitlab hash is $GITLAB_MD5_HASH
@@ -40,6 +42,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
     command: |
+      pwd
       zip -d TestBuildSource_BitbucketCloud.zip */.git/*
       export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
     onFailure:
@@ -49,6 +52,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
     command: |
+      pwd
       zip -d TestBuildSource_BitbucketServer.zip */.git/*
       export BITBUCKET_SERVER_MD5_HASH=`md5sum TestBuildSource_BitbucketServer.zip | awk '{ print $1 }'`
     onFailure:
@@ -58,6 +62,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
     command: |
+      pwd
       zip -d TestBuildSource_PublicGitlabServer.zip */.git/*
       export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum TestBuildSource_PublicGitlabServer.zip | awk '{ print $1 }'`
     onFailure:
@@ -67,6 +72,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of VBS Large Repo"
     command: |
+      pwd
       zip -d TestBuildSource_Vbs.zip */.git/*
       export VBS_MD5_HASH=`md5sum TestBuildSource_Vbs.zip | awk '{ print $1 }'`
     onFailure:

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -13,9 +13,14 @@ env:
    - VBS_MD5_HASH
 steps:
   - type: Command
-    name: "Calculating MD5 Hash of Github Large Repo"
+    name: Listing all files
     command: |
       cd ..
+      ls -al
+  - type: Command
+    name: "Calculating MD5 Hash of Github Large Repo"
+    command: |
+#      cd ..
       zip -d TestBuildSource_GitHub.zip */.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
       echo Github hash is $GITHUB_MD5_HASH
@@ -37,7 +42,7 @@ steps:
     name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
     command: |
       zip -d TestBuildSource_BitbucketCloud.zip */.git/*
-      export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
+      export BITUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
     onFailure:
       - type: Command
         command: |

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -13,14 +13,9 @@ env:
    - VBS_MD5_HASH
 steps:
   - type: Command
-    name: Listing all files
-    command: |
-      cd ..
-      ls -al
-  - type: Command
     name: "Calculating MD5 Hash of Github Large Repo"
     command: |
-      pwd
+      cd ${OCI_WORKSPACE_DIR}
       zip -d TestBuildSource_GitHub.zip */.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
       echo Github hash is $GITHUB_MD5_HASH
@@ -31,7 +26,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Gitlab Large Repo"
     command: |
-      pwd
+      cd ${OCI_WORKSPACE_DIR}
       zip -d TestBuildSource_GitLab.zip */.git/*
       export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
       echo Gitlab hash is $GITLAB_MD5_HASH
@@ -42,7 +37,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
     command: |
-      pwd
+      cd ${OCI_WORKSPACE_DIR}
       zip -d TestBuildSource_BitbucketCloud.zip */.git/*
       export BITBUCKET_CLOUD_MD5_HASH=`md5sum TestBuildSource_BitbucketCloud.zip | awk '{ print $1 }'`
     onFailure:
@@ -52,7 +47,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
     command: |
-      pwd
+      cd ${OCI_WORKSPACE_DIR}
       zip -d TestBuildSource_BitbucketServer.zip */.git/*
       export BITBUCKET_SERVER_MD5_HASH=`md5sum TestBuildSource_BitbucketServer.zip | awk '{ print $1 }'`
     onFailure:
@@ -62,7 +57,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
     command: |
-      pwd
+      cd ${OCI_WORKSPACE_DIR}
       zip -d TestBuildSource_PublicGitlabServer.zip */.git/*
       export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum TestBuildSource_PublicGitlabServer.zip | awk '{ print $1 }'`
     onFailure:
@@ -72,7 +67,7 @@ steps:
   - type: Command
     name: "Calculating MD5 Hash of VBS Large Repo"
     command: |
-      pwd
+      cd ${OCI_WORKSPACE_DIR}
       zip -d TestBuildSource_Vbs.zip */.git/*
       export VBS_MD5_HASH=`md5sum TestBuildSource_Vbs.zip | awk '{ print $1 }'`
     onFailure:

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -1,0 +1,95 @@
+version: 0.1
+component: build
+timeoutInSeconds: 20000
+runAs: root
+shell: bash
+env:
+  variables:
+    "githubSource": "TestBuildSource1_GitHub"
+    "gitlabSource": "TestBuildSource1_GitLab"
+    "bitbucketCloudSource": "TestBuildSource1_BitbucketCloud"
+    "bitbucketServerSource": "TestBuildSource1_BitbucketServer"
+    "publicGitlabServerSource": "TestBuildSource1_PublicGitlabServer"
+    "vbsSource": "TestBuildSource1_Vbs"
+    "zipFilesDirectoryName": "zipFiles"
+  exportedVariables:
+   - GITHUB_MD5_HASH
+   - GITLAB_MD5_HASH
+   - BITBUCKET_CLOUD_MD5_HASH
+   - BITBUCKET_SERVER_MD5_HASH
+   - PUBLIC_GITLAB_SERVER_MD5_HASH
+   - VBS_MD5_HASH
+steps:
+  - type: Command
+    name: "Create directory for storing zip files"
+    command: |
+      mkdir ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}
+  - type: Command
+    name: "Calculating MD5 Hash of Github Large Repo"
+    command: |
+      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/github.zip ${OCI_WORKSPACE_DIR}/${githubSource}
+      export GITHUB_MD5_HASH=`md5sum github.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of Github Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of Gitlab Large Repo"
+    command: |
+      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/gitlab.zip ${OCI_WORKSPACE_DIR}/${gitlabSource}
+      export GITLAB_MD5_HASH=`md5sum gitlab.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of Gitlab Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of Bitbucket Cloud Large Repo"
+    command: |
+      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/bitbucketCloud.zip ${OCI_WORKSPACE_DIR}/${bitbucketCloudSource}
+      export BITBUCKET_CLOUD_MD5_HASH=`md5sum bitbucketCloud.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of Bitbucket Cloud Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of Bitbucket Server Large Repo"
+    command: |
+      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/bitbucketServer.zip ${OCI_WORKSPACE_DIR}/${bitbucketServerSource}
+      export BITBUCKET_SERVER_MD5_HASH=`md5sum bitbucketServer.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of Bitbucket Server Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of Public Gitlab Server Large Repo"
+    command: |
+      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/publicGitlabServer.zip ${OCI_WORKSPACE_DIR}/${publicGitlabServerSource}
+      export PUBLIC_GITLAB_SERVER_MD5_HASH=`md5sum publicGitlabServer.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of Public Gitlab Server Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of VBS Large Repo"
+    command: |
+      zip -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}/vbs.zip ${OCI_WORKSPACE_DIR}/${vbsSource}
+      export VBS_MD5_HASH=`md5sum vbs.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of VBS Large Repo failed :("
+  - type: Command
+    name: "Deleting all the zip files"
+    command: |
+      rm -r ${OCI_WORKSPACE_DIR}/${zipFilesDirectoryName}
+#  - type: Command
+#    name: "Building spark (Github Large Repo) in local"
+#    command: |
+#      cd ${OCI_WORKSPACE_DIR}/${githubSource}
+#      chmod -R +x ./build/mvn
+#      ./build/mvn -DskipTests clean package
+#  - type: Command
+#    name: "run the Pi example locally"
+#    command: |
+#      chmod -R +x .
+#      ./bin/run-example SparkPi

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -11,6 +11,7 @@ env:
    - BITBUCKET_SERVER_MD5_HASH
    - PUBLIC_GITLAB_SERVER_MD5_HASH
    - VBS_MD5_HASH
+   - SCM_MD5_HASH
 steps:
   - type: Command
     name: "Calculating MD5 Hash of Github Large Repo"
@@ -72,6 +73,16 @@ steps:
       - type: Command
         command: |
           echo "Calculating MD5 Hash of VBS Large Repo failed :("
+  - type: Command
+    name: "Calculating MD5 Hash of SCM Large Repo"
+    command: |
+      cd ${OCI_WORKSPACE_DIR}
+      zip -dq TestBuildSource_Scm.zip */.git/*
+      export SCM_MD5_HASH=`md5sum TestBuildSource_Scm.zip | awk '{ print $1 }'`
+    onFailure:
+      - type: Command
+        command: |
+          echo "Calculating MD5 Hash of SCM Large Repo failed :("
   - type: Command
     name: "Building spark (Github Large Repo)"
     command: |

--- a/buildspec_combined.yaml
+++ b/buildspec_combined.yaml
@@ -18,7 +18,6 @@ steps:
       cd ${OCI_WORKSPACE_DIR}
       zip -d TestBuildSource_GitHub.zip */.git/*
       export GITHUB_MD5_HASH=`md5sum TestBuildSource_GitHub.zip | awk '{ print $1 }'`
-      echo Github hash is $GITHUB_MD5_HASH
     onFailure:
       - type: Command
         command: |
@@ -29,7 +28,6 @@ steps:
       cd ${OCI_WORKSPACE_DIR}
       zip -d TestBuildSource_GitLab.zip */.git/*
       export GITLAB_MD5_HASH=`md5sum TestBuildSource_GitLab.zip | awk '{ print $1 }'`
-      echo Gitlab hash is $GITLAB_MD5_HASH
     onFailure:
       - type: Command
         command: |


### PR DESCRIPTION
**Problem Statement**
Currently we have a large repo canary test for each build source type. This is redundant so we are merging them into one test with two aims:
* To check whether large repos from each build source are downloaded properly(by comparing MD5 hashes of downloaded files)
* To check if we can support large builds

**Tickets**
[DLCBLD-4025](https://jira.oci.oraclecorp.com/browse/DLCBLD-4025)

**Changes Made**
* Added new buildspec file which is meant for this new combined large repo canary